### PR TITLE
#69: Remove related `histoire` files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,6 @@
     "nuxt",
     "nuxtjs",
     "composables",
-    "histoire",
     "pinia",
     "persistedstate",
     "vueuse"

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@histoire/plugin-vue/components" />

--- a/histoire.setup.ts
+++ b/histoire.setup.ts
@@ -1,6 +1,0 @@
-import { defineSetupVue3 } from "@histoire/plugin-vue";
-
-export const setupVue3 = defineSetupVue3(({ app }) => {
-  const pinia = createPinia();
-  app.use(pinia);
-});


### PR DESCRIPTION
## Issues

closed #69 .

## Context

- `histoire`に関連する以下のファイルを削除しました
  - [x] `histoire.setup.ts`
  - [x] `end.d.ts`
  - [x] `.vscode/settings.json`内の`cSpell.userWords`