### PR TITLE
chore: fix renovate rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,13 +4,18 @@
   "extends": [
     "config:base",
     "@nuxtjs",
-    ":prConcurrentLimit20",
     ":semanticCommitTypeAll(chore)",
     ":enableVulnerabilityAlertsWithLabel(security)",
     "schedule:earlyMondays"
   ],
+  "prConcurrentLimit": 10,
   "labels": ["🤖 renovate"],
-  "timezone": "UTC",
+  "timezone": "Asia/Tokyo",
+  "reviewers": ["shinGangan"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "reviewers": ["shinGangan"]
+  },
   "packageRules": [
     {
       "groupName": "nuxt framework",


### PR DESCRIPTION
## Context

- [x] renovate.jsonに以下を追加
  - reviewers
  - timezone -> 'Asia/Tokyo'に変更
  - prConcurrentLimit -> extendsから変更。limit数は10に変更
